### PR TITLE
feat(agents): add JetBrains AI Assistant and Junie support

### DIFF
--- a/slash_commands/config.py
+++ b/slash_commands/config.py
@@ -15,6 +15,7 @@ class CommandFormat(str, Enum):
     TOML = "toml"
     KIRO = "kiro"
     KIRO_IDE = "kiro-ide"
+    JUNIE = "junie"
 
 
 @dataclass(frozen=True)
@@ -28,6 +29,8 @@ class AgentConfig:
     command_file_extension: str
     detection_dirs: tuple[str, ...]
     platform_command_dirs: dict[str, str] | None = None
+    use_subdirectory_layout: bool = False
+    fixed_filename: str | None = None
 
     def iter_detection_dirs(self) -> Iterable[str]:
         """Return an iterator over configured detection directories."""
@@ -143,6 +146,15 @@ _SUPPORTED_AGENT_DATA: tuple[
         None,
     ),
     (
+        "jetbrains-ai-assistant",
+        "JetBrains AI Assistant",
+        ".aiassistant/rules",
+        CommandFormat.KIRO,
+        ".md",
+        (".aiassistant",),
+        None,
+    ),
+    (
         "kiro-cli",
         "Kiro CLI",
         ".kiro/prompts",
@@ -164,25 +176,44 @@ _SUPPORTED_AGENT_DATA: tuple[
 
 _SORTED_AGENT_DATA = tuple(sorted(_SUPPORTED_AGENT_DATA, key=lambda item: item[0]))
 
-SUPPORTED_AGENTS: tuple[AgentConfig, ...] = tuple(
+_EXTRA_AGENTS: tuple[AgentConfig, ...] = (
     AgentConfig(
-        key=key,
-        display_name=display_name,
-        command_dir=command_dir,
-        command_format=command_format,
-        command_file_extension=command_file_extension,
-        detection_dirs=detection_dirs,
-        platform_command_dirs=platform_command_dirs,
+        key="junie",
+        display_name="Junie",
+        command_dir=".junie/skills",
+        command_format=CommandFormat.JUNIE,
+        command_file_extension=".md",
+        detection_dirs=(".junie",),
+        use_subdirectory_layout=True,
+        fixed_filename="SKILL.md",
+    ),
+)
+
+SUPPORTED_AGENTS: tuple[AgentConfig, ...] = tuple(
+    sorted(
+        [
+            AgentConfig(
+                key=key,
+                display_name=display_name,
+                command_dir=command_dir,
+                command_format=command_format,
+                command_file_extension=command_file_extension,
+                detection_dirs=detection_dirs,
+                platform_command_dirs=platform_command_dirs,
+            )
+            for (
+                key,
+                display_name,
+                command_dir,
+                command_format,
+                command_file_extension,
+                detection_dirs,
+                platform_command_dirs,
+            ) in _SORTED_AGENT_DATA
+        ]
+        + list(_EXTRA_AGENTS),
+        key=lambda a: a.key,
     )
-    for (
-        key,
-        display_name,
-        command_dir,
-        command_format,
-        command_file_extension,
-        detection_dirs,
-        platform_command_dirs,
-    ) in _SORTED_AGENT_DATA
 )
 
 _AGENT_LOOKUP: Mapping[str, AgentConfig] = {agent.key: agent for agent in SUPPORTED_AGENTS}

--- a/slash_commands/generators.py
+++ b/slash_commands/generators.py
@@ -403,6 +403,66 @@ class KiroIdeCommandGenerator:
         return _normalize_output(output)
 
 
+class JunieCommandGenerator:
+    """Generator for Junie Agent Skills (SKILL.md with YAML frontmatter).
+
+    Junie expects skills in subdirectories with a SKILL.md file containing
+    YAML frontmatter with required ``name`` and ``description`` fields per
+    the Agent Skills specification (https://agentskills.io/specification).
+    """
+
+    def generate(
+        self,
+        prompt: MarkdownPrompt,
+        agent: AgentConfig,
+        source_metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Generate a Junie SKILL.md file.
+
+        Args:
+            prompt: The source prompt to generate from
+            agent: The agent configuration
+            source_metadata: Optional source metadata (local or GitHub)
+
+        Returns:
+            Markdown with Junie Agent Skills frontmatter
+        """
+        description, arguments, _enabled = _apply_agent_overrides(prompt, agent)
+
+        # Sanitize name per Agent Skills spec: lowercase a-z, numbers, hyphens only,
+        # 1-64 chars, no leading/trailing hyphens, no consecutive hyphens.
+        skill_name = _strip_ordering_prefix(prompt.name).lower()
+        skill_name = re.sub(r"[^a-z0-9-]", "-", skill_name)
+        skill_name = re.sub(r"-{2,}", "-", skill_name).strip("-")[:64]
+
+        # Build Junie YAML frontmatter
+        frontmatter: dict[str, Any] = {
+            "name": skill_name,
+            "description": (description or prompt.name)[:1024],
+        }
+
+        # Replace placeholders in body
+        body = _replace_placeholders(prompt.body, arguments, replace_double_braces=True)
+
+        # Format as YAML frontmatter + body
+        yaml_content = yaml.safe_dump(frontmatter, allow_unicode=True, sort_keys=False)
+        output = f"---\n{yaml_content}---\n\n{body}\n"
+
+        # Append tracking metadata as a trailing HTML comment
+        meta_lines = [
+            f"source: {prompt.name}",
+            f"version: {__version__}",
+            f"updated: {datetime.now(UTC).strftime('%Y-%m-%d')}",
+        ]
+        if source_metadata:
+            if "source_repo" in source_metadata:
+                meta_lines.append(f"repo: {source_metadata['source_repo']}")
+
+        output += "\n<!-- slash-command-manager: " + " | ".join(meta_lines) + " -->\n"
+
+        return _normalize_output(output)
+
+
 class CommandGenerator:
     """Base class for command generators."""
 
@@ -417,5 +477,7 @@ class CommandGenerator:
             return KiroCommandGenerator()
         elif format == CommandFormat.KIRO_IDE:
             return KiroIdeCommandGenerator()
+        elif format == CommandFormat.JUNIE:
+            return JunieCommandGenerator()
         else:
             raise ValueError(f"Unsupported command format: {format}")

--- a/slash_commands/writer.py
+++ b/slash_commands/writer.py
@@ -299,6 +299,21 @@ class SlashCommandWriter:
         safe_stem = re.sub(r"[^A-Za-z0-9._-]+", "-", safe_stem).strip("-_.") or "command"
         return f"{safe_stem}{extension}"
 
+    def _build_output_path(self, prompt_name: str, agent: AgentConfig) -> Path:
+        """Build the output file path for a prompt and agent.
+
+        For agents with subdirectory layout (e.g. Junie), the path is:
+            base_path / command_dir / <sanitized-name> / SKILL.md
+
+        For flat agents, the path is:
+            base_path / command_dir / <sanitized-name>.ext
+        """
+        if agent.use_subdirectory_layout and agent.fixed_filename:
+            dir_name = self._sanitize_filename(prompt_name, "")
+            return self.base_path / agent.get_command_dir() / dir_name / agent.fixed_filename
+        filename = self._sanitize_filename(prompt_name, agent.command_file_extension)
+        return self.base_path / agent.get_command_dir() / filename
+
     def _find_existing_files(
         self, prompts: list[MarkdownPrompt], agent_configs: list[AgentConfig]
     ) -> list[Path]:
@@ -316,10 +331,7 @@ class SlashCommandWriter:
             if not prompt.enabled:
                 continue
             for agent in agent_configs:
-                # Determine output path (same logic as _generate_file)
-                filename = self._sanitize_filename(prompt.name, agent.command_file_extension)
-                output_path = self.base_path / agent.get_command_dir() / filename
-
+                output_path = self._build_output_path(prompt.name, agent)
                 if output_path.exists():
                     existing_files.append(output_path)
         return existing_files
@@ -378,9 +390,7 @@ class SlashCommandWriter:
         content = generator.generate(prompt, agent, self._source_metadata)
 
         # Determine output path (resolve relative to base_path)
-        # Sanitize file stem: drop any path components and restrict to safe chars
-        filename = self._sanitize_filename(prompt.name, agent.command_file_extension)
-        output_path = self.base_path / agent.get_command_dir() / filename
+        output_path = self._build_output_path(prompt.name, agent)
 
         # Handle existing files
         if output_path.exists():
@@ -453,7 +463,12 @@ class SlashCommandWriter:
                     continue
 
                 # Check for regular command files
-                for file_path in command_dir.glob(f"*{agent.command_file_extension}"):
+                if agent.use_subdirectory_layout and agent.fixed_filename:
+                    glob_pattern = f"*/{agent.fixed_filename}"
+                else:
+                    glob_pattern = f"*{agent.command_file_extension}"
+
+                for file_path in command_dir.glob(glob_pattern):
                     if self._is_generated_file(file_path, agent):
                         # Convert Path to string explicitly using os.fspath
                         path_str = os.fspath(file_path)
@@ -469,22 +484,41 @@ class SlashCommandWriter:
 
                 # Check for backup files
                 if include_backups:
-                    # Look for files matching the backup pattern: *.extension.timestamp.bak
-                    escaped_ext = re.escape(agent.command_file_extension)
-                    pattern = re.compile(rf".*{escaped_ext}\.\d{{8}}-\d{{6}}\.bak$")
-                    for file_path in command_dir.iterdir():
-                        if file_path.is_file() and pattern.match(file_path.name):
-                            # Convert Path to string explicitly using os.fspath
-                            path_str = os.fspath(file_path)
-                            found_files.append(
-                                {
-                                    "path": path_str,
-                                    "agent": agent.key,
-                                    "agent_display_name": agent.display_name,
-                                    "type": "backup",
-                                    "reason": "Matches backup pattern",
-                                }
-                            )
+                    if agent.use_subdirectory_layout and agent.fixed_filename:
+                        # For subdirectory layout, backups are inside subdirectories
+                        escaped_fn = re.escape(agent.fixed_filename)
+                        pattern = re.compile(rf".*{escaped_fn}\.\d{{8}}-\d{{6}}\.bak$")
+                        for subdir in command_dir.iterdir():
+                            if subdir.is_dir():
+                                for file_path in subdir.iterdir():
+                                    if file_path.is_file() and pattern.match(file_path.name):
+                                        path_str = os.fspath(file_path)
+                                        found_files.append(
+                                            {
+                                                "path": path_str,
+                                                "agent": agent.key,
+                                                "agent_display_name": agent.display_name,
+                                                "type": "backup",
+                                                "reason": "Matches backup pattern",
+                                            }
+                                        )
+                    else:
+                        # Look for files matching the backup pattern: *.extension.timestamp.bak
+                        escaped_ext = re.escape(agent.command_file_extension)
+                        pattern = re.compile(rf".*{escaped_ext}\.\d{{8}}-\d{{6}}\.bak$")
+                        for file_path in command_dir.iterdir():
+                            if file_path.is_file() and pattern.match(file_path.name):
+                                # Convert Path to string explicitly using os.fspath
+                                path_str = os.fspath(file_path)
+                                found_files.append(
+                                    {
+                                        "path": path_str,
+                                        "agent": agent.key,
+                                        "agent_display_name": agent.display_name,
+                                        "type": "backup",
+                                        "reason": "Matches backup pattern",
+                                    }
+                                )
             except KeyError:
                 # Agent key not found, skip
                 continue
@@ -510,7 +544,7 @@ class SlashCommandWriter:
             return self._is_generated_markdown(content)
         elif agent.command_format.value == "toml":
             return self._is_generated_toml(content)
-        elif agent.command_format.value in ("kiro", "kiro-ide"):
+        elif agent.command_format.value in ("kiro", "kiro-ide", "junie"):
             return self._is_generated_kiro(content)
         return False
 
@@ -598,6 +632,15 @@ class SlashCommandWriter:
             if not dry_run:
                 try:
                     file_path.unlink()
+                    # Remove empty parent subdirectory for subdirectory-layout agents
+                    try:
+                        agent = get_agent_config(file_info["agent"])
+                        if agent.use_subdirectory_layout:
+                            parent = file_path.parent
+                            if parent.exists() and not any(parent.iterdir()):
+                                parent.rmdir()
+                    except (KeyError, OSError):
+                        pass
                     deleted_files.append(file_info)
                 except OSError as e:
                     errors.append({"path": str(file_path), "error": str(e)})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,7 +22,8 @@ def test_command_format_defines_markdown_toml_and_kiro():
     assert CommandFormat.TOML.value == "toml"
     assert CommandFormat.KIRO.value == "kiro"
     assert CommandFormat.KIRO_IDE.value == "kiro-ide"
-    assert {member.value for member in CommandFormat} == {"markdown", "toml", "kiro", "kiro-ide"}
+    assert CommandFormat.JUNIE.value == "junie"
+    assert {member.value for member in CommandFormat} == {"markdown", "toml", "kiro", "kiro-ide", "junie"}
 
 
 def test_agent_config_is_frozen_dataclass():
@@ -68,8 +69,10 @@ def test_supported_agents_have_valid_structure(
             or agent.command_dir.endswith("/command")
             or agent.command_dir.endswith("/agents")
             or agent.command_dir.endswith("/steering")
+            or agent.command_dir.endswith("/rules")
+            or agent.command_dir.endswith("/skills")
         ), (
-            f"{agent.key}: command_dir must end with /commands, /prompts, /global_workflows, /command, /agents, or /steering"
+            f"{agent.key}: command_dir must end with /commands, /prompts, /global_workflows, /command, /agents, /steering, /rules, or /skills"
         )
         # File extension must start with a dot
         assert agent.command_file_extension.startswith("."), (
@@ -100,10 +103,11 @@ def test_supported_agents_have_valid_command_formats(
         CommandFormat.TOML,
         CommandFormat.KIRO,
         CommandFormat.KIRO_IDE,
+        CommandFormat.JUNIE,
     }
     for agent in supported_agents_by_key.values():
         assert agent.command_format in valid_formats, (
-            f"{agent.key}: command_format must be MARKDOWN, TOML, KIRO, or KIRO_IDE"
+            f"{agent.key}: command_format must be MARKDOWN, TOML, KIRO, KIRO_IDE, or JUNIE"
         )
 
 
@@ -142,3 +146,23 @@ def test_detection_dirs_cover_command_directory_roots(
             command_root = agent.command_dir.split("/", 1)[0]
             assert command_root in agent.detection_dirs
         assert isinstance(agent.detection_dirs, Iterable)
+
+
+def test_junie_agent_has_subdirectory_layout(
+    supported_agents_by_key: dict[str, AgentConfig],
+):
+    """Validate that junie agent uses subdirectory layout."""
+    junie = supported_agents_by_key["junie"]
+    assert junie.use_subdirectory_layout is True
+    assert junie.fixed_filename == "SKILL.md"
+
+
+def test_default_agents_have_flat_layout(
+    supported_agents_by_key: dict[str, AgentConfig],
+):
+    """Validate that non-junie agents default to flat file layout."""
+    for agent in supported_agents_by_key.values():
+        if agent.key == "junie":
+            continue
+        assert agent.use_subdirectory_layout is False
+        assert agent.fixed_filename is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,13 @@ def test_command_format_defines_markdown_toml_and_kiro():
     assert CommandFormat.KIRO.value == "kiro"
     assert CommandFormat.KIRO_IDE.value == "kiro-ide"
     assert CommandFormat.JUNIE.value == "junie"
-    assert {member.value for member in CommandFormat} == {"markdown", "toml", "kiro", "kiro-ide", "junie"}
+    assert {member.value for member in CommandFormat} == {
+        "markdown",
+        "toml",
+        "kiro",
+        "kiro-ide",
+        "junie",
+    }
 
 
 def test_agent_config_is_frozen_dataclass():

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -7,6 +7,8 @@ import pytest
 from mcp_server.prompt_utils import parse_frontmatter
 from slash_commands.config import get_agent_config
 from slash_commands.generators import (
+    CommandGenerator,
+    JunieCommandGenerator,
     KiroCommandGenerator,
     KiroIdeCommandGenerator,
     MarkdownCommandGenerator,
@@ -389,6 +391,32 @@ def test_kiro_generator_snapshot_regression(sample_prompt):
     assert not generated.startswith("---")
 
 
+# -- JetBrains AI Assistant generator tests ------------------------------------
+
+
+def test_jetbrains_rules_uses_kiro_generator():
+    """Test that JetBrains AI Assistant uses KiroCommandGenerator via factory."""
+    from slash_commands.config import CommandFormat
+
+    generator = CommandGenerator.create(CommandFormat.KIRO)
+    assert isinstance(generator, KiroCommandGenerator)
+
+
+def test_jetbrains_rules_produces_plain_markdown(sample_prompt):
+    """Test that JetBrains AI Assistant produces plain markdown with tracking comment."""
+    agent = get_agent_config("jetbrains-ai-assistant")
+    generator = KiroCommandGenerator()
+
+    generated = generator.generate(sample_prompt, agent)
+
+    # Should NOT have YAML frontmatter
+    assert not generated.startswith("---")
+    # Should contain prompt body
+    assert "# Sample Prompt" in generated
+    # Should have tracking comment
+    assert "<!-- slash-command-manager:" in generated
+
+
 # -- Kiro IDE agent generator tests --------------------------------------------
 
 
@@ -457,6 +485,126 @@ def test_kiro_ide_generator_snapshot_regression(sample_prompt):
     """Snapshot-style test to catch unintended changes in Kiro IDE output format."""
     agent = get_agent_config("kiro-ide")
     generator = KiroIdeCommandGenerator()
+
+    generated = generator.generate(sample_prompt, agent)
+
+    # Must have frontmatter
+    assert generated.startswith("---\n")
+    assert "\n---\n" in generated
+
+    # Must end with newline
+    assert generated.endswith("\n")
+
+    # No trailing whitespace in lines
+    for line in generated.splitlines():
+        assert line == line.rstrip(), "Line contains trailing whitespace"
+
+    # Consistent line endings (LF only)
+    assert "\r" not in generated
+
+    # Must have tracking comment at end
+    assert generated.strip().endswith("-->")
+
+
+# -- Junie agent skill generator tests ----------------------------------------
+
+
+def test_junie_generator_produces_frontmatter(sample_prompt):
+    """Test that JunieCommandGenerator produces markdown with required frontmatter fields."""
+    agent = get_agent_config("junie")
+    generator = JunieCommandGenerator()
+
+    generated = generator.generate(sample_prompt, agent)
+    frontmatter, body = _extract_frontmatter_and_body(generated)
+
+    assert frontmatter["name"] == "sample-prompt"
+    assert "description" in frontmatter
+    # Should NOT have markdown-generator fields
+    assert "tags" not in frontmatter
+    assert "arguments" not in frontmatter
+    assert "meta" not in frontmatter
+    assert "enabled" not in frontmatter
+
+    assert "# Sample Prompt" in body
+
+
+def test_junie_generator_sanitizes_name():
+    """Test that Junie generator sanitizes name per Agent Skills spec."""
+    from pathlib import Path
+
+    from mcp_server.prompt_utils import MarkdownPrompt
+
+    prompt = MarkdownPrompt(
+        name="SDD-1-My_Complex.Prompt!Name",
+        description="Test",
+        tags=[],
+        arguments=[],
+        enabled=True,
+        body="# Test",
+        path=Path("test.md"),
+        meta={},
+    )
+
+    agent = get_agent_config("junie")
+    generator = JunieCommandGenerator()
+
+    generated = generator.generate(prompt, agent)
+    frontmatter, _ = _extract_frontmatter_and_body(generated)
+
+    name = frontmatter["name"]
+    # Must be lowercase, a-z, 0-9, hyphens only
+    assert name == name.lower()
+    assert all(c in "abcdefghijklmnopqrstuvwxyz0123456789-" for c in name)
+    # No leading/trailing hyphens
+    assert not name.startswith("-")
+    assert not name.endswith("-")
+    # No consecutive hyphens
+    assert "--" not in name
+
+
+def test_junie_generator_includes_tracking_comment(sample_prompt):
+    """Test that tracking metadata is appended as a trailing HTML comment."""
+    agent = get_agent_config("junie")
+    generator = JunieCommandGenerator()
+
+    generated = generator.generate(sample_prompt, agent)
+
+    assert "<!-- slash-command-manager:" in generated
+    assert "source: sample-prompt" in generated
+    assert "version:" in generated
+    assert "updated:" in generated
+
+
+def test_junie_generator_replaces_placeholders(prompt_with_placeholder_body):
+    """Test that argument placeholders are replaced in the prompt body."""
+    agent = get_agent_config("junie")
+    generator = JunieCommandGenerator()
+
+    generated = generator.generate(prompt_with_placeholder_body, agent)
+
+    assert "$ARGUMENTS" not in generated
+    assert "{{args}}" not in generated
+    assert "query" in generated
+
+
+def test_junie_generator_github_source_metadata(sample_prompt):
+    """Test that GitHub repo is included in tracking comment."""
+    agent = get_agent_config("junie")
+    generator = JunieCommandGenerator()
+
+    source_metadata = {
+        "source_repo": "liatrio-labs/spec-driven-workflow",
+    }
+
+    generated = generator.generate(sample_prompt, agent, source_metadata)
+
+    assert "repo: liatrio-labs/spec-driven-workflow" in generated
+
+
+def test_junie_generator_snapshot_regression(sample_prompt):
+    """Snapshot-style test to catch unintended changes in Junie output format."""
+    agent = get_agent_config("junie")
+    generator = JunieCommandGenerator()
 
     generated = generator.generate(sample_prompt, agent)
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -979,6 +979,111 @@ def test_writer_finds_generated_kiro_ide_agent_files(tmp_path):
     assert found_files[0]["type"] == "command"
 
 
+def test_writer_generates_jetbrains_rules_files(mock_prompt_load: Path, tmp_path):
+    """Test that writer generates JetBrains AI Assistant project rule files."""
+    prompts_dir = mock_prompt_load
+
+    writer = SlashCommandWriter(
+        prompts_dir=prompts_dir,
+        agents=["jetbrains-ai-assistant"],
+        dry_run=False,
+        base_path=tmp_path,
+    )
+
+    writer.generate()
+
+    rules_output_dir = tmp_path / ".aiassistant" / "rules"
+    assert rules_output_dir.exists()
+
+    md_files = list(rules_output_dir.glob("*.md"))
+    assert len(md_files) > 0
+
+    for md_file in md_files:
+        content = md_file.read_text()
+        assert not content.startswith("---")  # No frontmatter (plain markdown)
+        assert "<!-- slash-command-manager:" in content  # Has tracking comment
+
+
+def test_writer_generates_junie_skill_in_subdirectory(mock_prompt_load: Path, tmp_path):
+    """Test that writer generates Junie skills in subdirectory layout."""
+    prompts_dir = mock_prompt_load
+
+    writer = SlashCommandWriter(
+        prompts_dir=prompts_dir,
+        agents=["junie"],
+        dry_run=False,
+        base_path=tmp_path,
+    )
+
+    writer.generate()
+
+    skills_output_dir = tmp_path / ".junie" / "skills"
+    assert skills_output_dir.exists()
+
+    # Should create a subdirectory with SKILL.md inside
+    skill_file = skills_output_dir / "test-prompt" / "SKILL.md"
+    assert skill_file.exists()
+
+    content = skill_file.read_text()
+    assert content.startswith("---")  # Has frontmatter
+    assert "name:" in content
+    assert "description:" in content
+    assert "<!-- slash-command-manager:" in content  # Has tracking comment
+
+
+def test_writer_finds_generated_junie_skill_files(tmp_path):
+    """Test that writer can find generated Junie skill files in subdirectories."""
+    skill_dir = tmp_path / ".junie" / "skills" / "test-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+
+    generated_file = skill_dir / "SKILL.md"
+    generated_file.write_text(
+        "---\nname: test-skill\ndescription: Test skill\n---\n\n"
+        "# Test Skill\n\nDo things.\n\n"
+        "<!-- slash-command-manager: source: test-prompt | version: 1.0.0 | updated: 2026-04-02 -->\n"
+    )
+
+    writer = SlashCommandWriter(
+        prompts_dir=tmp_path / "prompts",
+        agents=[],
+        dry_run=False,
+        base_path=tmp_path,
+    )
+
+    found_files = writer.find_generated_files(agents=["junie"], include_backups=False)
+
+    assert len(found_files) == 1
+    assert found_files[0]["path"] == str(generated_file)
+    assert found_files[0]["agent"] == "junie"
+    assert found_files[0]["type"] == "command"
+
+
+def test_writer_cleanup_junie_removes_empty_subdirectory(tmp_path):
+    """Test that cleanup removes empty parent subdirectory after deleting SKILL.md."""
+    skill_dir = tmp_path / ".junie" / "skills" / "test-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+
+    generated_file = skill_dir / "SKILL.md"
+    generated_file.write_text(
+        "---\nname: test-skill\ndescription: Test skill\n---\n\n"
+        "# Test Skill\n\n"
+        "<!-- slash-command-manager: source: test-prompt | version: 1.0.0 | updated: 2026-04-02 -->\n"
+    )
+
+    writer = SlashCommandWriter(
+        prompts_dir=tmp_path / "prompts",
+        agents=[],
+        dry_run=False,
+        base_path=tmp_path,
+    )
+
+    result = writer.cleanup(agents=["junie"], include_backups=False, dry_run=False)
+
+    assert result["files_deleted"] == 1
+    assert not generated_file.exists()
+    assert not skill_dir.exists()  # Empty parent should be removed
+
+
 def test_writer_generates_kiro_ide_agent_files(mock_prompt_load: Path, tmp_path):
     """Test that writer generates Kiro IDE steering markdown files."""
     prompts_dir = mock_prompt_load


### PR DESCRIPTION
Add two new agents for JetBrains IDEs:
- JetBrains AI Assistant: generates project rules in .aiassistant/rules/ as plain markdown with tracking comments (reuses KIRO format)
- Junie: generates Agent Skills in .junie/skills/<name>/SKILL.md with YAML frontmatter (name + description) per the Agent Skills spec

Introduces subdirectory layout support in AgentConfig for Junie's skill-per-directory structure, with corresponding writer changes for path construction, file discovery, and cleanup.

## Why?

<!-- Summarize the motivation for this change. Reference issues or requirements as needed. -->

## What Changed?

<!-- Call out the key updates in this PR. -->

## Testing

<!-- Describe how you tested these changes. -->

## Additional Notes

<!-- Optional: document follow-ups, rollout concerns, or reviewer guidance. -->

## Checklist

- [ ] Linked related issues (e.g., `Closes #123`)
- [ ] Ran tests and all pass
- [ ] Ran linters/hooks: `pre-commit run --all-files`
- [ ] Updated documentation if behavior changed
- [ ] Followed conventional commit message format
